### PR TITLE
ROMMON Upgrade

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -14,8 +14,8 @@ ASR1000-RP2:
   filename: asr1000rp2-adventerprisek9.03.16.04b.S.155-3.S4b-ext.bin
   rommon: asr1000-rommon.163-2r.pkg
 
-ASR1000-FOO:
-  filename: asr1000rp2-adventerprisek9.02.04.04.122-33.XND4.bin
+ASR1000-RP1:
+  filename: asr1000rp1-adventerprisek9.03.16.04b.S.155-3.S4b-ext.bin
   rommon: asr1000-rommon.163-2r.pkg
 
 CSR1000V:

--- a/pyosupgrade/procedures/asr1000.py
+++ b/pyosupgrade/procedures/asr1000.py
@@ -59,6 +59,8 @@ class ASR1000Upgrade(IOSUpgrade):
         # TODO verify this is the appropriate RP1 output
         elif "ASR1000-RP1" in output:
             return "ASR1000-RP1", output
+        elif "ASR1002-RP1" in output:
+            return "ASR1000-RP1", output
         else:
             return "UNKNOWN", output
 

--- a/pyosupgrade/procedures/asr1000.py
+++ b/pyosupgrade/procedures/asr1000.py
@@ -108,7 +108,7 @@ class ASR1000Upgrade(IOSUpgrade):
         self.status = "TRANSFERRING IOS"
         print("Initatiating file transfer...")
         url = "tftp://{}/{}".format(regional_fs, image)
-        ios_transfer, ios_transfer_output = generic.copy_remote_image(device, url)
+        ios_transfer, ios_transfer_output = generic.copy_remote_image(device, url, expect1="bytes copied", expect2="Signature Verified")
         rommon = images[sup_type]['rommon']
 
         self.status = "TRANSFERRING ROMMON"

--- a/pyosupgrade/tasks/generic.py
+++ b/pyosupgrade/tasks/generic.py
@@ -39,7 +39,7 @@ def verify_sup_redundancy(device):
     return "Standby hot" in output, output
 
 
-def copy_remote_image(device, url, file_system="bootflash:"):
+def copy_remote_image(device, url, file_system="bootflash:", expect1="bytes copied", expect2="signature successfully verified"):
     """
 
     :param device: pyntc device
@@ -69,7 +69,7 @@ def copy_remote_image(device, url, file_system="bootflash:"):
         command = 'copy {} {}{}'.format(url, file_system, image)
         output = device.native.send_command_expect(command, delay_factor=30)
         # look for all the following keywords in the output
-        expected_patterns = ["bytes copied", "signature successfully verified"]
+        expected_patterns = [expect1, expect2]
         try:
             if all(x in output for x in expected_patterns):
                 print "Image copied and successfully verified"
@@ -137,6 +137,9 @@ def verify_image(device, image):
     output = device.native.send_command_expect('verify {}'.format(image),
                                                delay_factor=10)
     if "signature successfully verified" in output:
+        return True, output
+    # common ASR1K pattern
+    elif "verification successful" in output:
         return True, output
     else:
         return False, output

--- a/regions.yaml
+++ b/regions.yaml
@@ -11,3 +11,5 @@ AS:
   regional_fs: 10.122.1.10
 KC:
   regional_fs: 192.168.51.1
+BR:
+  regional_fs: 10.87.2.10


### PR DESCRIPTION
Code needs to be verified in lab and via sanity check.

generic.py:
+Line 205-206:
`
def upgrade_rommon (device, rommon, file_system="bootflash:"):
    """
    Removes existing boot statements on *device* and adds one for *image*
    also saves the configuration

    :param device: ntc_device object
    :param rommon: str rommon filename
    :param file_system: str filesystem name, defaults to 'bootflash:'
    :returns: None
    """
    device.open()
    
    output = ""
    
    rommon_output = device.show('show platform | be Firmware')
    output += rommon_output
    
    # Determine slots requiring ROMMON upgrade, excluding 16.3(2r)
    excluded_lines = ['Slot','CPLD','16.3(2r)','-----']
    lines = output.rstrip().split('\n')
    lines = [l for l in lines if not any(s in l for s in excluded_lines)]
    expected_rommon_upgrades = len(lines)

    # Upgrade ROMMON
    print ("Updating ROMMON")
    command = 'upgrade rom-monitor filename {}{} all'.format(file_system, rommon)
    output += device.native.send_command_expect(command, delay_factor=90)
    
    # Verify ROMMON 

    num_upgraded_modules = output.count("ROMMON upgrade complete")
	if num_upgraded_modules == expected_rommon_upgrades:
        print("ROMMON upgrade complete")
        return True, output
     else:
        print("ROMMON upgrade failed")
        return False, output
`

asr1000.py:
+Line 22-23:
`
                 ('Upgrade ROMMON', self.set_rommon_status, self.set_rommon_log_url),
`

! Line 110-111
`
        self.status = "LOCATING ROMMON"
        rommon = images[sup_type]['rommon']

        print("Using image {}".format(rommon))
        self.target_rommon = rommon
`

+Line 208-209:
`
        # Upgrade ROMMON
        self.status = "UPGRADING ROMMON"
        result = generic.upgrade_rommon(connected, rommon=self.target_rommon)
        rommon_result, rommon_output = result
        if rommon_output:
            logbin_url = self.logbin(rommon_output, description="upgrading rommon for {}".format(self.device))
            self.set_rommon_status_log_url = logbin_url
            self.set_rommon_status = "success"
        else:
            self.status = "FAILED - COULD NOT UPGRADE ROMMON"
            exit()
`

! Line 241-261
`
 	# here we are formatting the output that will be pushed to the logbin
        # so that it will be able to be viewed as an iframe
        image_output = '\nDetecting image name with `sho ver | inc image`\n'
        image_output += online.show('sho ver | inc image')
        image_output += '\nDetecting uptime with `show ver | inc ptime`\n'
        image_output += online.show('sho ver | inc ptime')

        # some platforms may have limitation in how many chars of the boot image display
        # so we'll do our part to shorten our image name
        match_pattern = self.target_image.split('.bin')[0]
        upgraded = match_pattern in image_output
        image_output += "\nChecking if {} is present in the output...".format(match_pattern)
        
        if upgraded:
            print("\nFound {} in command output".format(self.target_image))
            image_output += "it is"
			image_upgraded = True
        else:
            print("\nCould not find {} in command output\n".format(self.target_image))
            image_output += "rur roh"
            image_upgraded = False
            
    	rommon_output = device.show('show platform | be Firmware')
    	image_output += '\nDetecting ROMMON with `show platform | be Firmware`\n'
    	image_output += rommon_output
    
  		# Determine slots requiring ROMMON upgrade, excluding 16.3(2r)
    	excluded_lines = ['Slot','CPLD','16.3(2r)','-----']
    	lines = rommon_output.rstrip().split('\n')
    	lines = [l for l in lines if not any(s in l for s in excluded_lines)]
    	expected_rommon_upgrades = len(lines)
    
    	if expected_rommon_upgrades == 0:
     	 print("\n16.3(2r) ROMMON seen for all modules)
     	 rommon_upgraded = True
    	else:
     	 print("\n16.3(2r) ROMMON not seen for one or more modules\n")
     	 rommon_upgraded = False
     	 
     	 if image_upgraded == False or rommon_upgraded == False
     	  self.verify_upgrade = "danger"
     	 else:
     	   self.verify_upgrade = "success"
`


